### PR TITLE
Fix Research misspelling

### DIFF
--- a/docs/mkdocs.yaml
+++ b/docs/mkdocs.yaml
@@ -1,4 +1,4 @@
-site_name: Deep Reasearch with DeepSeek R1 and LangChain
+site_name: Deep Research with DeepSeek R1 and LangChain
 site_url: http://aka.ms/build/lab331
 site_author: Microsoft
 site_description: >-

--- a/docs/site/404.html
+++ b/docs/site/404.html
@@ -20,7 +20,7 @@
     
     
       
-        <title>Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -85,7 +85,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href="/build/lab331/." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="/build/lab331/." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -99,7 +99,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -221,13 +221,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href="/build/lab331/." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="/build/lab331/." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/getting-started/index.html
+++ b/docs/site/getting-started/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Getting Started - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Getting Started - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/includes/introduction-event/index.html
+++ b/docs/site/includes/introduction-event/index.html
@@ -22,7 +22,7 @@
     
     
       
-        <title>Introduction event - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Introduction event - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -101,7 +101,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href="../.." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="../.." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -115,7 +115,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -237,13 +237,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href="../.." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="../.." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/includes/introduction-self-guided/index.html
+++ b/docs/site/includes/introduction-self-guided/index.html
@@ -22,7 +22,7 @@
     
     
       
-        <title>Introduction self guided - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Introduction self guided - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -101,7 +101,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href="../.." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="../.." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -115,7 +115,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -237,13 +237,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href="../.." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="../.." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/index.html
+++ b/docs/site/index.html
@@ -24,7 +24,7 @@
     
     
       
-        <title>Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -103,7 +103,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href="." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -117,7 +117,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -239,13 +239,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href="." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href="." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/lab-1-introduction-to-reasoning-models/index.html
+++ b/docs/site/lab-1-introduction-to-reasoning-models/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Lab 1: Introduction to Reasoning Models - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Lab 1: Introduction to Reasoning Models - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/lab-2-web-research/index.html
+++ b/docs/site/lab-2-web-research/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Lab 2: Web Research Integration - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Lab 2: Web Research Integration - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/lab-3-reflection/index.html
+++ b/docs/site/lab-3-reflection/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Lab 3: Research Reflection - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Lab 3: Research Reflection - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/lab-4-launch-researcher/index.html
+++ b/docs/site/lab-4-launch-researcher/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Lab 4: Launching Your Researcher - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Lab 4: Launching Your Researcher - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/resources/index.html
+++ b/docs/site/resources/index.html
@@ -26,7 +26,7 @@
     
     
       
-        <title>Resources - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Resources - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -105,7 +105,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -119,7 +119,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -241,13 +241,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">

--- a/docs/site/summary/index.html
+++ b/docs/site/summary/index.html
@@ -24,7 +24,7 @@
     
     
       
-        <title>Summary - Deep Reasearch with DeepSeek R1 and LangChain</title>
+        <title>Summary - Deep Research with DeepSeek R1 and LangChain</title>
       
     
     
@@ -103,7 +103,7 @@
 
 <header class="md-header md-header--shadow md-header--lifted" data-md-component="header">
   <nav class="md-header__inner md-grid" aria-label="Header">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-header__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
@@ -117,7 +117,7 @@
       <div class="md-header__ellipsis">
         <div class="md-header__topic">
           <span class="md-ellipsis">
-            Deep Reasearch with DeepSeek R1 and LangChain
+            Deep Research with DeepSeek R1 and LangChain
           </span>
         </div>
         <div class="md-header__topic" data-md-component="header-topic">
@@ -239,13 +239,13 @@
 
 <nav class="md-nav md-nav--primary" aria-label="Navigation" data-md-level="0">
   <label class="md-nav__title" for="__drawer">
-    <a href=".." title="Deep Reasearch with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Reasearch with DeepSeek R1 and LangChain" data-md-component="logo">
+    <a href=".." title="Deep Research with DeepSeek R1 and LangChain" class="md-nav__button md-logo" aria-label="Deep Research with DeepSeek R1 and LangChain" data-md-component="logo">
       
   
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M12 8a3 3 0 0 0 3-3 3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3m0 3.54C9.64 9.35 6.5 8 3 8v11c3.5 0 6.64 1.35 9 3.54 2.36-2.19 5.5-3.54 9-3.54V8c-3.5 0-6.64 1.35-9 3.54"/></svg>
 
     </a>
-    Deep Reasearch with DeepSeek R1 and LangChain
+    Deep Research with DeepSeek R1 and LangChain
   </label>
   
     <div class="md-nav__source">


### PR DESCRIPTION
## Summary
- fix typos of "Reasearch" to "Research" in docs

## Testing
- `pytest -q` *(fails: command not found)*